### PR TITLE
Register the event subscriber in the boot method

### DIFF
--- a/src/Tobiassjosten/Silex/ResponsibleServiceProvider.php
+++ b/src/Tobiassjosten/Silex/ResponsibleServiceProvider.php
@@ -22,13 +22,12 @@ class ResponsibleServiceProvider implements ServiceProviderInterface
         if (empty($app['serializer'])) {
             $app->register(new SerializerServiceProvider());
         }
-
-        $app['dispatcher']->addSubscriber(
-            new ResponsibleListener($app['serializer'])
-        );
     }
 
     public function boot(Application $app)
     {
+        $app['dispatcher']->addSubscriber(
+            new ResponsibleListener($app['serializer'])
+        );
     }
 }


### PR DESCRIPTION
The method `ServiceProviderInterface::register()` must never use a service.
