### PR TITLE
allow newer versions of silex and symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "silex/silex": "~1.0",
-        "symfony/serializer": ">=2.1,<2.5-dev"
+        "symfony/serializer": "~2.1"
     },
     "require-dev":{
-        "symfony/browser-kit": ">=2.1,<2.5-dev"
+        "symfony/browser-kit": "~2.1"
     },
     "autoload": {
         "psr-0": { "Tobiassjosten\\Silex": "src" }


### PR DESCRIPTION
bumped the silex to allow >=1.0 and <2.0
bumped symfony components to allow <2.5-dev

If you prefer to lock silex to known compatible versions, I can make it ">=1.0, <1.3"
