### PR TITLE
if */* is the only accept option, change it to the Content-Type received...

### DIFF
--- a/src/Tobiassjosten/Silex/ResponsibleListener.php
+++ b/src/Tobiassjosten/Silex/ResponsibleListener.php
@@ -42,7 +42,7 @@ class ResponsibleListener implements EventSubscriberInterface
 
         // If Accept is blank, then */* is the only option available.
         // Change it to the current Content-Type to attempt returning the format received
-        if (count($accepted) === 1 && $accepted[0] == '*/*') {
+        if (count($accepted) === 1 && $accepted[0] === '*/*') {
             $accepted[0] = $request->headers->get('Content-Type');
         }
 


### PR DESCRIPTION
... in order to attempt to return the type that was received.

_/_ happens when no Accept header is sent.
